### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Vactor0911/wanna-trip-server/security/code-scanning/7](https://github.com/Vactor0911/wanna-trip-server/security/code-scanning/7)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only deploys code to a server and does not interact with the repository or other GitHub features, we will set the permissions to `contents: read`. This ensures that the workflow has the minimal permissions required and adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
